### PR TITLE
Turns out, wiring up marginalia is _trivial_. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ pom.xml.asc
 *.class
 /.lein-*
 /.nrepl-port
+/docs

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [markdown-clj "0.9.63"]
                  [me.raynes/fs "1.4.6"]]
+  :plugins [[lein-marginalia "0.8.0"]]
   :main ^:skip-aot doctopus.core
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})


### PR DESCRIPTION
This brings in the marginalia lein plugin (allowing doc generation with `lein marg`); also,
adds the 'docs' generated directory to the project `.gitignore`.
