### PR TITLE
Smash the state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,7 @@ lein: lein2
 jdk:
   - oraclejdk7
 env: NOMAD_ENV=travis
+addons:
+  postgresql "9.3"
+before_script:
+  - psql -c 'create database doctopus_test;' -U postgres

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ jdk:
   - oraclejdk7
 env: NOMAD_ENV=travis
 addons:
-  postgresql "9.3"
+  postgresql: "9.3"
 before_script:
   - psql -c 'create database doctopus_test;' -U postgres

--- a/resources/configuration.edn
+++ b/resources/configuration.edn
@@ -7,5 +7,8 @@
                                     :ip "0.0.0.0"}
                       "travis" {:heads-dir "resources/self/heads"
                                 :permanent-fs-root "~/"
-                                :ip 8080}}
+                                :ip 8080
+                                :database {:test {:user "postgres"
+                                                  :password ""
+                                                  :db "doctopus_test"}}}}
  }

--- a/resources/configuration.edn
+++ b/resources/configuration.edn
@@ -7,7 +7,7 @@
                                     :ip "0.0.0.0"}
                       "travis" {:heads-dir "resources/self/heads"
                                 :permanent-fs-root "~/"
-                                :ip 8080
+                                :port 8080
                                 :database {:test {:user "postgres"
                                                   :password ""
                                                   :db "doctopus_test"}}}}

--- a/resources/self/heads/main/doctopus.edn
+++ b/resources/self/heads/main/doctopus.edn
@@ -1,6 +1,6 @@
 {:output-root "docs"
  :html-commands ["lein marg -f index.html"]
  :name "doctopus"
- :source-control :git
+ :source-control "git"
  :source-location "https://github.com/Gastove/doctopus.git"
  :entry-point "index.html"}

--- a/resources/test/heads/test/doctopus-test.edn
+++ b/resources/test/heads/test/doctopus-test.edn
@@ -1,6 +1,6 @@
 {:output-root "docs"
  :html-commands ["lein marg -f index.html"]
  :name "doctopus-test"
- :source-control :git
+ :source-control "git"
  :source-location "https://github.com/Gastove/doctopus.git"
  :entry-point "index.html"}

--- a/resources/test/heads/test/doctopus-test.edn
+++ b/resources/test/heads/test/doctopus-test.edn
@@ -1,5 +1,5 @@
 {:output-root "docs"
- :html-commands ["lein marg -f index.html"]
+ :html-commands ["git checkout smash-the-state" "lein marg -f index.html"]
  :name "doctopus-test"
  :source-control "git"
  :source-location "https://github.com/Gastove/doctopus.git"

--- a/src/doctopus/db.clj
+++ b/src/doctopus/db.clj
@@ -32,6 +32,7 @@
              (select-keys (:database (server-config))
                           [:db :user :password :host :port])))
 
+(declare head-tentacle-mappings)
 (defentity tentacles
   (pk :name)
   (has-many head-tentacle-mappings)
@@ -53,17 +54,24 @@
   (prepare add-updated)
   (prepare ->snake-keys)
   (transform ->kebab-keys)
-  (has-many head-tentacle-mappings {:fk :head_name})
-  ;; (has-many tentacles {:fk :head_name})
-  )
+  (has-many head-tentacle-mappings))
 
+
+;; ### Head <-> Tentacle Join Table
+;; Heads and Tentacles can share the notorious SQL many-to-many
+;; relationship. Further, having either a head or a tentacle record _on the
+;; database_ storing information about the other gets conceptually weird. Enter:
+;; the join table.
+;;
+;; Join tables capture many-to-many relationships by inserting themselves in the
+;; middle, effectively creating a one-to-many relationship between itself and
+;; both of the other tables you're attempting to look up. Getting from Heads to
+;; Tentacles (or vice-versa) is now a set of left-joins. Easy peasy!
 (defentity head-tentacle-mappings
-  (fk :head-name)
-  (fk :tentacle-name)
   (prepare ->snake-keys)
   (transform ->kebab-keys)
-  (has-one heads {:fk :name})
-  (has-one tentacles {:fk :name}))
+  (belongs-to heads)
+  (belongs-to tentacles))
 
 (defn get-tentacle
   [name]

--- a/src/doctopus/db.clj
+++ b/src/doctopus/db.clj
@@ -17,9 +17,9 @@
   "adds created and updated fields to a map with given time"
   ([fields] (add-date-fields fields (now)))
   ([fields now-string]
-  (let [new-fields (assoc fields :updated now-string)]
-    (if (:created new-fields) new-fields
-      (assoc new-fields :created now-string)))))
+   (let [new-fields (assoc fields :updated now-string)]
+     (if (:created new-fields) new-fields
+         (assoc new-fields :created now-string)))))
 
 (defn- ->kebab-keys
   "converts all keys in a map to kebab-case keywords"
@@ -32,22 +32,23 @@
   (transform-keys ->snake_case_keyword fields))
 
 (defdb main (postgres
-           (select-keys (:database (server-config))
-                        [:db :user :password :host :port])))
+             (select-keys (:database (server-config))
+                          [:db :user :password :host :port])))
 
 (defentity tentacles
   (pk :name)
+  (has-many head-tentacle-mappings)
   (prepare add-date-fields)
   (prepare (fn [{html-commands :html-commands :as tentacle}]
-            (if html-commands
-              (assoc tentacle :html-commands (string/join "\n" html-commands))
-              tentacle)))
+             (if html-commands
+               (assoc tentacle :html-commands (string/join "\n" html-commands))
+               tentacle)))
   (prepare ->snake-keys)
   (transform ->kebab-keys)
   (transform (fn [{html-commands :html-commands :as tentacle}]
-              (if html-commands
-                (assoc tentacle :html-commands (split-lines html-commands))
-                tentacle))))
+               (if html-commands
+                 (assoc tentacle :html-commands (split-lines html-commands))
+                 tentacle))))
 
 
 (defentity heads

--- a/src/doctopus/db.clj
+++ b/src/doctopus/db.clj
@@ -110,18 +110,25 @@
   (select tentacles-by-head
           (where {:head_name (:name head)})))
 
-(defn save-tentacle!
+(defn create-tentacle!
   [tentacle]
-  (log/info "Saving tentacle:" tentacle)
+  (log/info "Creating new tentacle in the db:" tentacle)
   (insert tentacles
           (values tentacle)))
 
 (defn update-tentacle!
   [tentacle]
-  (log/info "Updating tentacle" (:name tentacle) "with values:" tentacle)
+  (log/info "Record found, updating tentacle:" (:name tentacle) "with values:" tentacle)
   (update tentacles
           (set-fields tentacle)
           (where {:name (:name tentacle)})))
+
+(defn save-tentacle!
+  [tentacle]
+  (log/info "Saving tentacle" tentacle)
+  (if-not (empty? (get-tentacle (:name tentacle)))
+    (update-tentacle! tentacle)
+    (create-tentacle! tentacle)))
 
 (defn delete-tentacle!
   [tentacle]
@@ -144,7 +151,7 @@
   (select heads-by-tentacle
           (where {:tentacle_name (:name tentacle)})))
 
-(defn save-head!
+(defn create-head!
   [head]
   (log/info "Saving head:" head)
   (insert heads
@@ -152,10 +159,16 @@
 
 (defn update-head!
   [head]
-  (log/info "Updating head" (:name head) "with values" head)
+  (log/info "Updating head:" (:name head) "with values" head)
   (update heads
           (set-fields head)
           (where {:name (:name head)})))
+
+(defn save-head!
+  [head]
+  (if-not (empty? (get-head (:name head)))
+    (update-head! head)
+    (create-head! head)))
 
 (defn delete-head!
   [head]

--- a/src/doctopus/db.clj
+++ b/src/doctopus/db.clj
@@ -100,9 +100,9 @@
           (where {:name (:name tentacle)})))
 
 (defn delete-tentacle!
-  [name]
+  [tentacle]
   (delete tentacles
-          (where {:name name})))
+          (where {:name (:name tentacle)})))
 
 (defn get-head
   [name]
@@ -129,6 +129,6 @@
           (where {:name (:name head)})))
 
 (defn delete-head!
-  [name]
+  [head]
   (delete heads
-          (where {:name name})))
+          (where {:name (:name head)})))

--- a/src/doctopus/db.clj
+++ b/src/doctopus/db.clj
@@ -56,7 +56,17 @@
   (prepare add-date-fields)
   (prepare ->snake-keys)
   (transform ->kebab-keys)
-  (has-many tentacles {:fk :head_name}))
+  (has-many head-tentacle-mappings {:fk :head_name})
+  ;; (has-many tentacles {:fk :head_name})
+  )
+
+(defentity head-tentacle-mappings
+  (fk :head-name)
+  (fk :tentacle-name)
+  (prepare ->snake-keys)
+  (transform ->kebab-keys)
+  (has-one heads {:fk :name})
+  (has-one tentacles {:fk :name}))
 
 (defn get-tentacle
   [name]
@@ -67,6 +77,11 @@
 (defn get-all-tentacles
   []
   (select tentacles))
+
+(defn get-tentacles-for-head
+  [head]
+  (select tentacles
+          (where {:head-name (:name head)})))
 
 (defn save-tentacle!
   [tentacle]

--- a/src/doctopus/db.clj
+++ b/src/doctopus/db.clj
@@ -1,4 +1,4 @@
-(ns doctopus.db.core
+(ns doctopus.db
   (:require [korma.db :refer [defdb postgres]]
             [clojure.string :as string :refer [split-lines]]
             [korma.core :refer :all]
@@ -49,6 +49,7 @@
                 (assoc tentacle :html-commands (split-lines html-commands))
                 tentacle))))
 
+
 (defentity heads
   (pk :name)
   (prepare add-date-fields)
@@ -61,6 +62,10 @@
   (first (select tentacles
                  (where {:name name})
                  (limit 1))))
+
+(defn get-all-tentacles
+  []
+  (select tentacles))
 
 (defn save-tentacle!
   [tentacle]
@@ -82,13 +87,14 @@
   [name]
   (first (select heads
                  (where {:name name})
-                 (with tentacles)
+                 ;; (with tentacles)
                  (limit 1))))
 
 (defn get-all-heads
   []
   (select heads
-          (with tentacles)))
+          ;; (with tentacles)
+          ))
 
 (defn save-head!
   [head]

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -38,7 +38,6 @@
 
 (def tentacle-schema
   [[:name "varchar(50)" "PRIMARY KEY"]
-;   [:head_name "varchar(50)"]
    [:output_root "varchar(50)"]
    [:html_commands "varchar(250)"]
    [:source_control "varchar(50)"]

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -1,13 +1,14 @@
 (ns doctopus.db.schema
   (:require [clojure.java.jdbc :as sql]
-            [taoensso.timbre :as log]
-            [doctopus.configuration :refer [server-config]]))
+            [clojure.string :as str]
+            [doctopus.configuration :refer [server-config]]
+            [taoensso.timbre :as log]))
 
 (defn- get-subname
   "pull database options out of the local config"
   [{:keys [host port db] :or {host "localhost" port 5432 db "doctopus"}}]
-    (let [tpl "//%s:%d/%s"]
-      (format tpl host port db)))
+  (let [tpl "//%s:%d/%s"]
+    (format tpl host port db)))
 
 (def db-spec {:classname "org.postgresql.Driver"
               :subprotocol "postgresql"

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -48,7 +48,8 @@
 
 (def head-tentacle-schema
   [[:head_name "varchar(50) references heads(name) on delete cascade"]
-   [:tentacle_name "varchar(50) references tentacles(name) on delete cascade"]])
+   [:tentacle_name "varchar(50) references tentacles(name) on delete cascade"]
+   ["PRIMARY KEY(head_name, tentacle_name)"]])
 
 (defn do-sql-with-logging!
   [sql-statement db-name]

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -68,4 +68,4 @@
                 "head_tentacle_mappings" head-tentacle-schema}]
     (doseq [[table-name schema] assure]
       (when (not (table-created? table-name))
-        (create-table! "heads" schema)))))
+        (create-table! table-name schema)))))

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -20,7 +20,7 @@
   "check our database for a table"
   [table-name]
   (-> (sql/query db-spec [(str "select count(*) from information_schema.tables "
-                           "where table_name='" table-name "'")])
+                               "where table_name='" table-name "'")])
       first :count pos?))
 
 (def head-schema
@@ -40,8 +40,8 @@
    [:updated :timestamp "NOT NULL"]])
 
 (def head-tentacle-schema
-  [[:head-name "varchar(50)" "FOREIGN KEY"]
-   [:tentacle-name "varchar(50)" "FOREIGN KEY"]])
+  [[:head_name "varchar(50) references heads(name)"]
+   [:tentacle_name "varchar(50) references tentacles(name)"]])
 
 (defn- create-table!
   "creates a table with a given name and schema"

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -30,7 +30,7 @@
 
 (def tentacle-schema
   [[:name "varchar(50)" "PRIMARY KEY"]
-   [:head_name "varchar(50)"]
+;   [:head_name "varchar(50)"]
    [:output_root "varchar(50)"]
    [:html_commands "varchar(250)"]
    [:source_control "varchar(50)"]
@@ -38,6 +38,10 @@
    [:entry_point "varchar(50)"]
    [:created "varchar(50)" "NOT NULL"]
    [:updated "varchar(50)" "NOT NULL"]])
+
+(def head-tentacle-schema
+  [[:head-name "varchar(50)" "FOREIGN KEY"]
+   [:tentacle-name "varchar(50)" "FOREIGN KEY"]])
 
 (defn- create-table!
   "creates a table with a given name and schema"
@@ -50,8 +54,9 @@
 (defn bootstrap
   "checks for the presence of tables and creates them if necessary"
   []
-  (do
-   (when (not (table-created? "heads"))
-     (create-table! "heads" head-schema))
-   (when (not (table-created? "tentacles"))
-     (create-table! "tentacles" tentacle-schema))))
+  (let [assure {"heads" head-schema
+                "tentacles" tentacle-schema
+                "head_tentacle_mappings" head-tentacle-schema}]
+    (doseq [[table-name schema] assure]
+      (when (not (table-created? table-name))
+        (create-table! "heads" schema)))))

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -10,11 +10,18 @@
   (let [tpl "//%s:%d/%s"]
     (format tpl host port db)))
 
-(def db-spec {:classname "org.postgresql.Driver"
-              :subprotocol "postgresql"
-              :subname (get-subname (:database (server-config)))
-              :user (:user (:database (server-config)))
-              :password (:password (:database (server-config)))})
+(defn build-db-spec
+  [{:keys [user password] :as cfg-map}]
+  {:classname "org.postgresql.Driver"
+   :subprotocol "postgresql"
+   :subname (get-subname cfg-map)
+   :user user
+   :password password})
+
+(defn build-db-spec-by-name
+  [db-name]
+  (let [db-map (get-in (server-config) [:database db-name])]
+    (build-db-spec db-map)))
 
 (defn table-created?
   "check our database for a table"

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -25,9 +25,10 @@
 
 (defn table-created?
   "check our database for a table"
-  [table-name]
-  (-> (sql/query db-spec [(str "select count(*) from information_schema.tables "
-                               "where table_name='" table-name "'")])
+  [db-name table-name]
+  (-> (sql/query (build-db-spec-by-name db-name)
+                 [(str "select count(*) from information_schema.tables "
+                       "where table_name='" table-name "'")])
       first :count pos?))
 
 (def head-schema

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -70,14 +70,14 @@
                                (cons (keyword table-name) table-schema))
                         db-name))
 
-(def table-name->schema {"heads" head-schema
-                         "tentacles" tentacle-schema
-                         "head_tentacle_mappings" head-tentacle-schema})
+(def table-name-schema-pairs [["heads" head-schema]
+                              ["tentacles" tentacle-schema]
+                              ["head_tentacle_mappings" head-tentacle-schema]])
 
 (defn bootstrap
   "checks for the presence of tables and creates them if necessary"
   ([] (bootstrap :main))
   ([db-name]
-   (doseq [[table-name schema] table-name->schema]
+   (doseq [[table-name schema] table-name-schema-pairs]
      (when (not (table-created? db-name table-name))
        (create-table! db-name table-name schema)))))

--- a/src/doctopus/db/schema.clj
+++ b/src/doctopus/db/schema.clj
@@ -47,8 +47,8 @@
    [:updated :timestamp "NOT NULL"]])
 
 (def head-tentacle-schema
-  [[:head_name "varchar(50) references heads(name)"]
-   [:tentacle_name "varchar(50) references tentacles(name)"]])
+  [[:head_name "varchar(50) references heads(name) on delete cascade"]
+   [:tentacle_name "varchar(50) references tentacles(name) on delete cascade"]])
 
 (defn do-sql-with-logging!
   [sql-statement]

--- a/src/doctopus/doctopus.clj
+++ b/src/doctopus/doctopus.clj
@@ -25,11 +25,8 @@
     [configuration substitutions]
   DoctopusMethods
   (bootstrap-heads [this]
-    (let [heads-dir (:heads-dir configuration)
-          dirs (fs/list-dir heads-dir)
-          head-names (map #(.getName %) dirs)
-          heads (map #(h/Head. %) head-names)]
-      (doall (map #(h/bootstrap-tentacles % heads-dir substitutions) heads))))
+    (let [heads (map h/map->Head (db/get-all-heads))]
+      (doall (map #(h/bootstrap-tentacles % substitutions) heads))))
   (list-heads [this] (doall (map h/map->Head (db/get-all-heads))))
   (list-tentacles [this]
     (into [] (flatten (for [head (list-heads this)

--- a/src/doctopus/doctopus.clj
+++ b/src/doctopus/doctopus.clj
@@ -7,7 +7,8 @@
   Each Doctopus will have one or more Heads, which represent a logical grouping
   of docs, and some number of Tentacles -- individual sources of documentation
   orchestrated by the Head. "
-  (:require [doctopus.doctopus.head :as h]
+  (:require [doctopus.db :as db]
+            [doctopus.doctopus.head :as h]
             [doctopus.doctopus.tentacle :as t]
             [me.raynes.fs :as fs])
   (:import [doctopus.doctopus.head Head]))
@@ -28,20 +29,20 @@
           dirs (fs/list-dir heads-dir)
           head-names (map #(.getName %) dirs)
           heads (map #(h/Head. %) head-names)]
-      (assoc this :heads
-             (doall (map #(h/bootstrap-tentacles % heads-dir substitutions) heads)))))
-  (list-heads [this] (:heads this))
+      (doall (map #(h/bootstrap-tentacles % heads-dir substitutions) heads))))
+  (list-heads [this] (doall (map h/map->Head (db/get-all-heads))))
   (list-tentacles [this]
-    (into [] (flatten (for [head (:heads this)
-                    :let [tentacles (h/list-tentacles head)]]
-                tentacles))))
+    (into [] (flatten (for [head (list-heads this)
+                            :let [tentacles (h/list-tentacles head (:substitutions this))]]
+                        tentacles))))
   (list-tentacles-by-head [this head]
-    (map h/list-tentacles (filter #(= head (:name %)) (:heads this))))
+    (map #(h/list-tentacles % (:substitutions this))
+         (filter #(= head (:name %)) (list-heads this))))
   (load-routes [this]
     ;; You may be wondering, "what the hell is going on here". And that's a
     ;; great question! The answer is: we need to make sure that what's returned
     ;; is a map from the key "/" to a map of the form {tentacle-name
     ;; tentacle-routes}. This is not the prettiest, but it does just that.
     {"/" (apply merge (flatten (into [] (for [head (:heads this)
-                                  :let [route-map (h/load-tentacle-routes head)]]
-                              [route-map]))))}))
+                                              :let [route-map (h/load-tentacle-routes head (:substitutions this))]]
+                                          [route-map]))))}))

--- a/src/doctopus/doctopus/head.clj
+++ b/src/doctopus/doctopus/head.clj
@@ -18,8 +18,8 @@
 
 
 (defn split
-  [string]
-  (str/split string #" "))
+  [s]
+  (str/split s #" "))
 
 (defn injest-shell-strings
   "Takes a vector of shell commands, like:

--- a/src/doctopus/doctopus/head.clj
+++ b/src/doctopus/doctopus/head.clj
@@ -2,16 +2,20 @@
   (:require [clojure.edn :as edn]
             [clojure.string :as str]
             [doctopus.configuration :refer [server-config]]
+            [doctopus.db :as db]
             [doctopus.doctopus.tentacle :refer [map->Tentacle] :as t]
             [doctopus.shell :as sh]
             [me.raynes.fs :as fs]))
 
 (defn perform-substitutions!
+  "Given a map of {<term to look for> <replacement>} and a vector of words,
+  returns a new vector with key replaced by val."
   [subs-map cmd-vec]
   (letfn [(substitute [word] (if (contains? subs-map word)
                                (subs-map word)
                                word))]
     (map substitute cmd-vec)))
+
 
 (defn split
   [string]
@@ -36,6 +40,7 @@
         (map split)
         (perform-substitutions! subs-map)
         (vec))))
+
 
 (defn parse-tentacle-config-map
   ([unparsed-cfgs] (parse-tentacle-config-map unparsed-cfgs {}))

--- a/src/doctopus/doctopus/head.clj
+++ b/src/doctopus/doctopus/head.clj
@@ -51,7 +51,7 @@
 
 ;; Head
 (defprotocol HeadMethods
-  (bootstrap-tentacles [this root] [this root subs-map])
+  (bootstrap-tentacles [this] [this subs-map])
   (list-tentacles [this subs-map])
   (load-tentacle-routes [this subs-map]))
 
@@ -64,9 +64,9 @@
                              (parse-tentacle-config-map cfg-map subs-map))
           tentacles (map map->Tentacle tentacle-configs)]
       (doall tentacles)))
-  (bootstrap-tentacles [this root]
-    (bootstrap-tentacles this root {}))
-  (bootstrap-tentacles [this root subs-map]
+  (bootstrap-tentacles [this]
+    (bootstrap-tentacles this {}))
+  (bootstrap-tentacles [this subs-map]
     (let [tentacles (list-tentacles this subs-map)]
       (doseq [tentacle tentacles] (t/load-html tentacle))))
   (load-tentacle-routes [this subs-map]

--- a/src/doctopus/storage/impls/permanent_fs.clj
+++ b/src/doctopus/storage/impls/permanent_fs.clj
@@ -13,8 +13,7 @@
   (do (log/error "Configuration couldn't be correctly loaded. Most"
               "often, this is caused by an unset NOMAD_ENV"
               "environment variable; make sure NOMAD_ENV=dev,"
-              "and try again.")
-      (System/exit 1)))
+              "and try again. Until then, behavior may be very odd")))
 
 (if-not (fs/exists? root) (fs/mkdirs root))
 

--- a/test/doctopus/db_test.clj
+++ b/test/doctopus/db_test.clj
@@ -1,27 +1,10 @@
 (ns doctopus.db-test
   (:require [clojure.test :refer :all]
-            [clojure.java.jdbc :as jdbc]
-            [doctopus.configuration :refer [server-config]]
-            [doctopus.db :refer :all]
+            [doctopus
+             [db :refer :all]
+             [test-utilities :as utils]]
             [doctopus.db.schema :refer :all]
-            [doctopus.test-utilities :as utils]
-            [korma.core :as sql]
-            [korma.db :refer [defdb postgres]]))
-
-(defdb test-db (postgres
-                (select-keys (get-in (server-config) [:database :test])
-                             [:db :user :password :host :port])))
-
-(defn- truncate!
-  [table-name]
-  (let [sql-string (format "TRUNCATE %s CASCADE" table-name)]
-    (do-sql-with-logging! sql-string :test)))
-
-(defn database-fixture
-  [f]
-  (bootstrap :test)
-  (f)
-  (doseq [n (keys table-name->schema)] (truncate! n)))
+            [doctopus.test-database :refer [database-fixture]]))
 
 (use-fixtures :once database-fixture)
 

--- a/test/doctopus/db_test.clj
+++ b/test/doctopus/db_test.clj
@@ -1,25 +1,25 @@
 (ns doctopus.db-test
-  (:require [doctopus.db.core :refer :all]
+  (:require [doctopus.db :refer :all]
             [clojure.test :refer :all]))
 
 (deftest db
   (testing "->kebab-keys transforms all keys to kebab-case"
-    (is (= (#'doctopus.db.core/->kebab-keys {:key_name "lol"}) {:key-name "lol"}))
-    (is (= (#'doctopus.db.core/->kebab-keys {:key_name "lol" :another_key "heh"})
+    (is (= (#'doctopus.db/->kebab-keys {:key_name "lol"}) {:key-name "lol"}))
+    (is (= (#'doctopus.db/->kebab-keys {:key_name "lol" :another_key "heh"})
            {:key-name "lol" :another-key "heh"}))
-    (is (= (#'doctopus.db.core/->kebab-keys
+    (is (= (#'doctopus.db/->kebab-keys
             {:key_name "lol" :another_key "heh" :untouched-key "laffo"})
            {:key-name "lol" :another-key "heh" :untouched-key "laffo"})))
   (testing "->snake-keys transforms all keys to snake-case"
-    (is (= (#'doctopus.db.core/->snake-keys {:key-name "lol"}) {:key_name "lol"}))
-    (is (= (#'doctopus.db.core/->snake-keys {:key-name "lol" :another-key "heh"})
+    (is (= (#'doctopus.db/->snake-keys {:key-name "lol"}) {:key_name "lol"}))
+    (is (= (#'doctopus.db/->snake-keys {:key-name "lol" :another-key "heh"})
            {:key_name "lol" :another_key "heh"}))
-    (is (= (#'doctopus.db.core/->snake-keys
+    (is (= (#'doctopus.db/->snake-keys
             {:key-name "lol" :another-key "heh" :untouched_key "laffo"})
            {:key_name "lol" :another_key "heh" :untouched_key "laffo"})))
   (testing "add-date-fields adds updated and created fields"
-    (is (= (#'doctopus.db.core/add-date-fields {} "right-now")
+    (is (= (#'doctopus.db/add-date-fields {} "right-now")
            {:updated "right-now" :created "right-now"})))
   (testing "add-date-fields does not updated created if present"
-    (is (= (#'doctopus.db.core/add-date-fields {:created "earlier"} "right-now")
+    (is (= (#'doctopus.db/add-date-fields {:created "earlier"} "right-now")
            {:updated "right-now" :created "earlier"}))))

--- a/test/doctopus/db_test.clj
+++ b/test/doctopus/db_test.clj
@@ -65,10 +65,24 @@
     (testing "Can we save tentacles?"
       (doseq [tentacle mock-tentacles] (save-tentacle! tentacle))
       (is (= 5 (count (get-all-tentacles)))))
-    (testing "Can we save head-tentacle mappings?"
-      (doall (map #(create-mapping! % %2) mock-heads mock-tentacles))
-      (is (= 5 (count (get-all-mappings)))))
-    (doseq [head mock-heads
-            tentacle mock-tentacles]
-      (delete-head! head)
-      (delete-tentacle! tentacle))))
+
+    ;; For these next two tests, we'll want to be able to reference the first
+    ;; head and the first tentacle consistently and easily
+    (let [first-head (first mock-heads)
+          first-tent (first mock-tentacles)]
+      (testing "Can we save head-tentacle mappings?"
+        (doseq [tent mock-tentacles] (create-mapping! first-head tent))
+        (doseq [head mock-heads] (create-mapping! head first-tent))
+        ;; first-head and first-tentacle only need a single mapping
+        (is (= 9 (count (get-all-mappings)))))
+      (testing "Can we get the tentacles for a head, using the mapping?"
+        (is (= 5 (count (get-tentacles-for-head first-head)))))
+      (testing "Can we get the heads for a tentacle, using the mapping?"
+        (is (= 5 (count (get-heads-for-tentacle first-tent))))))
+    (testing "Can we delete heads and tentacles?"
+      (doall (for [head mock-heads] (delete-head! head)))
+      (doall (for [tent mock-tentacles] (delete-tentacle! tent)))
+      (is (= 0 (count (get-all-heads))))
+      (is (= 0 (count (get-all-tentacles)))))
+    (testing "Did the mappings table get updated correct?"
+      (is (= 0 (count (get-all-mappings)))))))

--- a/test/doctopus/db_test.clj
+++ b/test/doctopus/db_test.clj
@@ -4,7 +4,7 @@
              [db :refer :all]
              [test-utilities :as utils]]
             [doctopus.db.schema :refer :all]
-            [doctopus.test-database :refer [database-fixture]]))
+            [doctopus.test-database :refer [database-fixture truncate!]]))
 
 (use-fixtures :once database-fixture)
 
@@ -38,16 +38,21 @@
            "//meow:31/cats"))))
 
 (deftest db-joins-and-lookups
+  ;; When we bootstrap the database, it finishes with some data in it. Gonna be
+  ;; easier if we just pave that fresh for these tests
+  (truncate! "heads")
+  (truncate! "tentacles")
+  (truncate! "head_tentacle_mappings")
   (let [tentacle-mocker #(utils/mock-data :tentacle nil)
         mock-tentacles (take 5 (repeatedly tentacle-mocker))
         head-mocker #(utils/mock-data :head nil)
         mock-heads (take 5 (repeatedly head-mocker))]
     (testing "Can we save heads?"
       (doseq [head mock-heads] (save-head! head))
-      (is (= 5 (count (get-all-heads)))))
+      (is (= 5 (count (get-all-heads))) "We should have 5 saved heads"))
     (testing "Can we save tentacles?"
       (doseq [tentacle mock-tentacles] (save-tentacle! tentacle))
-      (is (= 5 (count (get-all-tentacles)))))
+      (is (= 5 (count (get-all-tentacles))) "We should have 5 saved tentacles"))
 
     ;; For these next two tests, we'll want to be able to reference the first
     ;; head and the first tentacle consistently and easily

--- a/test/doctopus/db_test.clj
+++ b/test/doctopus/db_test.clj
@@ -1,9 +1,31 @@
 (ns doctopus.db-test
-  (:require [doctopus.db :refer :all]
+  (:require [clojure.test :refer :all]
+            [clojure.java.jdbc :as jdbc]
+            [doctopus.configuration :refer [server-config]]
+            [doctopus.db :refer :all]
             [doctopus.db.schema :refer :all]
-            [clojure.test :refer :all]))
+            [doctopus.test-utilities :as utils]
+            [korma.core :as sql]
+            [korma.db :refer [defdb postgres]]))
 
-(deftest db
+(defdb test-db (postgres
+                (select-keys (get-in (server-config) [:database :test])
+                             [:db :user :password :host :port])))
+
+(defn- truncate!
+  [table-name]
+  (let [sql-string (format "TRUNCATE %s CASCADE" table-name)]
+    (do-sql-with-logging! sql-string :test)))
+
+(defn database-fixture
+  [f]
+  (bootstrap :test)
+  (f)
+  (doseq [n (keys table-name->schema)] (truncate! n)))
+
+(use-fixtures :once database-fixture)
+
+(deftest db-name-and-data-transforms
   (testing "->kebab-keys transforms all keys to kebab-case"
     (is (= (#'doctopus.db/->kebab-keys {:key_name "lol"}) {:key-name "lol"}))
     (is (= (#'doctopus.db/->kebab-keys {:key_name "lol" :another_key "heh"})
@@ -31,3 +53,22 @@
            "//meow:5432/cats"))
     (is (= (#'doctopus.db.schema/get-subname {:host "meow" :db "cats" :port 31})
            "//meow:31/cats"))))
+
+(deftest db-joins-and-lookups
+  (let [tentacle-mocker #(utils/mock-data :tentacle nil)
+        mock-tentacles (take 5 (repeatedly tentacle-mocker))
+        head-mocker #(utils/mock-data :head nil)
+        mock-heads (take 5 (repeatedly head-mocker))]
+    (testing "Can we save heads?"
+      (doseq [head mock-heads] (save-head! head))
+      (is (= 5 (count (get-all-heads)))))
+    (testing "Can we save tentacles?"
+      (doseq [tentacle mock-tentacles] (save-tentacle! tentacle))
+      (is (= 5 (count (get-all-tentacles)))))
+    (testing "Can we save head-tentacle mappings?"
+      (doall (map #(create-mapping! % %2) mock-heads mock-tentacles))
+      (is (= 5 (count (get-all-mappings)))))
+    (doseq [head mock-heads
+            tentacle mock-tentacles]
+      (delete-head! head)
+      (delete-tentacle! tentacle))))

--- a/test/doctopus/doctopus/head_test.clj
+++ b/test/doctopus/doctopus/head_test.clj
@@ -6,33 +6,22 @@
             [doctopus.doctopus.head :refer :all]
             [doctopus.doctopus.tentacle :as t]
             [doctopus.storage :as storage]
-            [doctopus.test-utilities :as utils]
-            [doctopus.test-database :refer [database-fixture]])
+            [doctopus.test-database :refer [database-fixture]]
+            [doctopus.test-utilities :as utils])
   (:import [doctopus.doctopus.head Head]))
 
 (use-fixtures :once database-fixture)
 
-(def test-head (Head. "test"))
-
-(def test-tentacle-props
-  (edn/read-string (slurp (io/resource "test/heads/test/doctopus-test.edn"))))
-
-(def one-tentacle (t/map->Tentacle test-tentacle-props))
-
 (storage/set-backend! :temp-fs)
 
-;; This test just needs re-writing -- doesn't do a damn thing we care about right
-;; now
-;; (deftest head-test
-;; (db/save-head! test-head)
-;; (db/save-tentacle! one-tentacle)
-;; (db/create-mapping! test-head one-tentacle)
-;;   (testing "Can we bootstrap a Head's tentacles?"
-;;     (let [tentacles (list-tentacles test-head {})]
-;;       (is (not (nil? tentacles)) "Should have tentacles now")
-;;       (is (= "doctopus-test" (:name (first tentacles))))
-;;       (is (= one-tentacle (first (tentacles)))))
-;;     (utils/clean-up-test-html "doctopus-test")))
+(deftest head-test
+  (testing "Can we bootstrap a Head's tentacles?"
+    (let [head (map->Head (db/get-head "main"))
+          tentacles (list-tentacles head {})]
+      (is (not (nil? tentacles)) "Should have tentacles now")
+      (is (= "doctopus" (:name (first tentacles)))
+          "Should have a tentacle with a known name"))
+    (utils/clean-up-test-html "doctopus-test")))
 
 (deftest injest-shell-strings-test
   (let [input-single-vec ["make -C docs/ html"]

--- a/test/doctopus/doctopus_test.clj
+++ b/test/doctopus/doctopus_test.clj
@@ -13,34 +13,24 @@
            [doctopus.doctopus.head Head]))
 
 (use-fixtures :once database-fixture)
+
 (storage/set-backend! :temp-fs)
 
-(def doctopus-test-configs
-  {:heads-dir (io/resource "test/heads")})
-
-(def test-tent-props
-  (edn/read-string (slurp (io/resource "test/heads/test/doctopus-test.edn"))))
-
-(def stunt-doctopus (Doctopus. doctopus-test-configs {}))
+(def stunt-doctopus (Doctopus. {} {}))
 
 (deftest doctopus-test
-  (let [test-head (Head. "test")
-        test-tent (t/map->Tentacle test-tent-props)]
-    (db/save-head! test-head)
-    (db/save-tentacle! test-tent)
-    (db/create-mapping! test-head test-tent)
-    (testing "Can we list heads?"
-      (is (not (empty? (list-heads stunt-doctopus))))
-      (is (= "test" (:name (first (list-heads stunt-doctopus))))))
-    (testing "Can we list tentacles?"
-      (let [tent-list (list-tentacles stunt-doctopus)]
-        (is (= 1 (count tent-list))
-            "We should only have one of these")
-        (is (= "doctopus-test" (:name (first tent-list)))
-            "Would sure be weird if we got a different tentacle here")))
-    (testing "Can we get a tentacle by its head?"
-      (is (= 1 (count (list-tentacles-by-head stunt-doctopus "test")))
-          "This should get one tentacle")
-      (is (empty? (list-tentacles-by-head stunt-doctopus "HOOBASTANK"))
-          "There should never, ever be a tentacle with this name. Ever.")))
-  (utils/clean-up-test-html "doctopus-test"))
+  (testing "Can we list heads?"
+    (is (not (empty? (list-heads stunt-doctopus))))
+    (is (= "main" (:name (first (list-heads stunt-doctopus))))))
+  (testing "Can we list tentacles?"
+    (let [tent-list (list-tentacles stunt-doctopus)]
+      (is (= 1 (count tent-list))
+          "We should only have one of these")
+      (is (= "doctopus" (:name (first tent-list)))
+          "Would sure be weird if we got a different tentacle here")))
+  (testing "Can we get a tentacle by its head?"
+    (is (= 1 (count (list-tentacles-by-head stunt-doctopus "main")))
+        "This should get one tentacle")
+    (is (empty? (list-tentacles-by-head stunt-doctopus "HOOBASTANK"))
+        "There should never, ever be a tentacle with this name. Ever."))
+  (utils/clean-up-test-html "doctopus"))

--- a/test/doctopus/doctopus_test.clj
+++ b/test/doctopus/doctopus_test.clj
@@ -1,38 +1,46 @@
 (ns doctopus.doctopus-test
-  (:require [clojure.java.io :as io]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.test :refer :all]
+            [doctopus.db :as db]
             [doctopus.doctopus.head :as h]
             [doctopus.doctopus :refer :all]
+            [doctopus.doctopus.tentacle :as t]
             [doctopus.storage :as storage]
+            [doctopus.test-database :refer [database-fixture]]
             [doctopus.test-utilities :as utils])
   (:import [doctopus.doctopus Doctopus]
            [doctopus.doctopus.head Head]))
 
+(use-fixtures :once database-fixture)
 (storage/set-backend! :temp-fs)
 
 (def doctopus-test-configs
   {:heads-dir (io/resource "test/heads")})
 
-;; Note: we *should* probably test bootstrapping heads here. HOWEVER, that's a
-;; mechanism we're about to change in a major (and good) way, so I'm not super
-;; inclined to mess with it until we get a Database and we can stop returning
-;; new Doctopi/Heads every time there's a state change :/ - RMD
-(def stunt-doctopus (bootstrap-heads (Doctopus. doctopus-test-configs {})))
+(def test-tent-props
+  (edn/read-string (slurp (io/resource "test/heads/test/doctopus-test.edn"))))
+
+(def stunt-doctopus (Doctopus. doctopus-test-configs {}))
 
 (deftest doctopus-test
-  (testing "Can we list heads?"
-    (let [test-head (h/bootstrap-tentacles (Head. "test") (io/resource "test/heads"))]
-      (is (= #{test-head} (set (list-heads stunt-doctopus))))
-      (is (= "test" (:name (first (list-heads stunt-doctopus)))))))
-  (testing "Can we list tentacles?"
-    (let [tent-list (list-tentacles stunt-doctopus)]
-      (is (= 1 (count tent-list))
-          "We should only have one of these")
-      (is (= "doctopus-test" (:name (first tent-list)))
-          "Would sure be weird if we got a different tentacle here")))
-  (testing "Can we get a tentacle by its head?"
-    (is (= 1 (count (list-tentacles-by-head stunt-doctopus "test")))
-        "This should get one tentacle")
-    (is (empty? (list-tentacles-by-head stunt-doctopus "HOOBASTANK"))
-        "There should never, ever be a tentacle with this name. Ever."))
+  (let [test-head (Head. "test")
+        test-tent (t/map->Tentacle test-tent-props)]
+    (db/save-head! test-head)
+    (db/save-tentacle! test-tent)
+    (db/create-mapping! test-head test-tent)
+    (testing "Can we list heads?"
+      (is (not (empty? (list-heads stunt-doctopus))))
+      (is (= "test" (:name (first (list-heads stunt-doctopus))))))
+    (testing "Can we list tentacles?"
+      (let [tent-list (list-tentacles stunt-doctopus)]
+        (is (= 1 (count tent-list))
+            "We should only have one of these")
+        (is (= "doctopus-test" (:name (first tent-list)))
+            "Would sure be weird if we got a different tentacle here")))
+    (testing "Can we get a tentacle by its head?"
+      (is (= 1 (count (list-tentacles-by-head stunt-doctopus "test")))
+          "This should get one tentacle")
+      (is (empty? (list-tentacles-by-head stunt-doctopus "HOOBASTANK"))
+          "There should never, ever be a tentacle with this name. Ever.")))
   (utils/clean-up-test-html "doctopus-test"))

--- a/test/doctopus/test_database.clj
+++ b/test/doctopus/test_database.clj
@@ -24,9 +24,13 @@
   (let [sql-string (format "TRUNCATE %s CASCADE" table-name)]
     (do-sql-with-logging! sql-string :test)))
 
+(defn obliterate!
+  []
+  (do-sql-with-logging! "DROP SCHEMA public CASCADE" :test)
+  (do-sql-with-logging! "CREATE  SCHEMA public" :test))
 
 (defn database-fixture
   [f]
   (bootstrap :test)
   (f)
-  (doseq [n (keys table-name->schema)] (truncate! n)))
+  (obliterate!))

--- a/test/doctopus/test_database.clj
+++ b/test/doctopus/test_database.clj
@@ -19,7 +19,7 @@
                 (select-keys (get-in (server-config) [:database :test])
                              [:db :user :password :host :port])))
 
-(defn- truncate!
+(defn truncate!
   [table-name]
   (let [sql-string (format "TRUNCATE %s CASCADE" table-name)]
     (do-sql-with-logging! sql-string :test)))

--- a/test/doctopus/test_database.clj
+++ b/test/doctopus/test_database.clj
@@ -1,0 +1,32 @@
+(ns doctopus.test-database
+  (:require [clojure.test :refer :all]
+            [doctopus.configuration :refer [server-config]]
+            [doctopus.db :refer :all]
+            [doctopus.db.schema :refer :all]
+            [korma.db :refer [defdb postgres]]
+            [clojure.test :refer :all]
+            [doctopus
+             [db :refer :all]]
+            [doctopus.db.schema :refer :all]
+            [clojure.test :refer :all]
+            [clojure.test :refer :all]
+            [doctopus
+             [db :refer :all]]
+            [doctopus.db.schema :refer :all]))
+
+
+(defdb test-db (postgres
+                (select-keys (get-in (server-config) [:database :test])
+                             [:db :user :password :host :port])))
+
+(defn- truncate!
+  [table-name]
+  (let [sql-string (format "TRUNCATE %s CASCADE" table-name)]
+    (do-sql-with-logging! sql-string :test)))
+
+
+(defn database-fixture
+  [f]
+  (bootstrap :test)
+  (f)
+  (doseq [n (keys table-name->schema)] (truncate! n)))

--- a/test/doctopus/test_utilities.clj
+++ b/test/doctopus/test_utilities.clj
@@ -1,5 +1,6 @@
 (ns doctopus.test-utilities
-  (:require [clojure.test :refer :all]
+  (:require [clojure.string :as str]
+            [clojure.test :refer :all]
             [doctopus.storage :refer [remove-from-storage backend]]
             [doctopus.test-utilities :refer :all])
   (:import [org.joda.time DateTime]
@@ -15,3 +16,25 @@
 (defn clean-up-test-html
   [k]
   (remove-from-storage backend k))
+
+(defmulti mock-data (fn [kind length] kind))
+
+(defmethod mock-data :int
+  [_ length]
+  (rand-int length))
+
+(defmethod mock-data :string
+  [_ length]
+  (let [upper-alphas "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        lower-alphas (str/lower-case upper-alphas)
+        nums "0123456789"
+        punct-and-spaces " -!,?:~_ \"'$%&"
+        candidate-chars (apply str
+                               upper-alphas
+                               lower-alphas
+                               nums
+                               punct-and-spaces)]
+    (loop [acc []]
+      (if (= (count acc) length)
+        (apply str acc)
+        (recur (conj acc (rand-nth candidate-chars)))))))

--- a/test/doctopus/test_utilities.clj
+++ b/test/doctopus/test_utilities.clj
@@ -46,6 +46,7 @@
   (map->Tentacle {:name (mock-data :string 10)
                   :html-commands [(mock-data :string 10)]
                   :output-root (mock-data :string 15)
+                  :source-control "git"
                   :source-location (mock-data :string 10)
                   :entry-point (mock-data :string 10)}))
 

--- a/test/doctopus/test_utilities.clj
+++ b/test/doctopus/test_utilities.clj
@@ -1,6 +1,8 @@
 (ns doctopus.test-utilities
   (:require [clojure.string :as str]
             [clojure.test :refer :all]
+            [doctopus.doctopus.head :refer [->Head]]
+            [doctopus.doctopus.tentacle :refer [map->Tentacle]]
             [doctopus.storage :refer [remove-from-storage backend]]
             [doctopus.test-utilities :refer :all])
   (:import [org.joda.time DateTime]
@@ -38,3 +40,15 @@
       (if (= (count acc) length)
         (apply str acc)
         (recur (conj acc (rand-nth candidate-chars)))))))
+
+(defmethod mock-data :tentacle
+  [_ _]
+  (map->Tentacle {:name (mock-data :string 10)
+                  :html-commands [(mock-data :string 10)]
+                  :output-root (mock-data :string 15)
+                  :source-location (mock-data :string 10)
+                  :entry-point (mock-data :string 10)}))
+
+(defmethod mock-data :head
+  [_ _]
+  (->Head (mock-data :string 18)))


### PR DESCRIPTION
Well.
#### Holy Shit

So this got a little intense. The goal is the resolution of #37, which will eventually be achieved by making the `Doctopus` stack approximately stateless. From there, things got a little hinky. 

The first thing I realized was that a `Head` and a `Tentacle` need a way to be mapped to each other -- but neither of those should be in charge of it. So, I started in on a join table (`head_tentacle_mappings`). Then I needed Korma to do lookups in the join table, and I wanted unit tests to make sure those were right. As long as I was there, I wanted unit tests for the rest of our DB interactions -- which lead me to some bug and function-fixes.

As this stands, it's... getting there. Some changes haven't been pushed yet (apologies), and this is definitely WIP. All the same: comments gratefully welcomed.
