### PR TITLE
replaces the injected iframe with the doctopus omnibar

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,6 +47,17 @@
                                    :output-dir "resources/public/assets/scripts"
                                    :asset-path "/assets/scripts"
                                    :optimizations :none
+                                   :pretty-print true}}
+                       {:id "dev-omni"
+                        :source-paths ["src-cljs"]
+                        :figwheel true
+                        :incremental false
+                        :compiler {:main doctopus.omni
+                                   :source-map "resources/public/assets/scripts/omni.js.map"
+                                   :output-to "resources/public/assets/scripts/omni.js"
+                                   :output-dir "resources/public/assets/scripts"
+                                   :asset-path "/assets/scripts"
+                                   :optimizations :none
                                    :pretty-print true}}]}
   :profiles {:uberjar {:aot :all
                        :prep-tasks ["compile" ["cljsbuild" "once" "prod"]]

--- a/project.clj
+++ b/project.clj
@@ -60,7 +60,7 @@
                                    :optimizations :none
                                    :pretty-print true}}]}
   :profiles {:uberjar {:aot :all
-                       :prep-tasks ["compile" ["cljsbuild" "once" "prod"]]
+                       :prep-tasks ["compile" ["cljsbuild" "once" "prod" "prod-omni"]]
                        :cljsbuild {:jar true
                                    :builds [{:id "prod"
                                              :source-paths ["src-cljs"]
@@ -68,6 +68,15 @@
                                              :compiler {:main doctopus.main
                                                         :source-map "resources/public/assets/scripts/main.js.map"
                                                         :output-to "resources/public/assets/scripts/main.js"
+                                                        :asset-path "/assets/scripts"
+                                                        :optimizations :advanced
+                                                        :pretty-print false}}
+                                            {:id "prod-omni"
+                                             :source-paths ["src-cljs"]
+                                             :figwheel false
+                                             :compiler {:main doctopus.omni
+                                                        :source-map "resources/public/assets/scripts/omni.js.map"
+                                                        :output-to "resources/public/assets/scripts/omni.js"
                                                         :asset-path "/assets/scripts"
                                                         :optimizations :advanced
                                                         :pretty-print false}}]}}})

--- a/resources/public/assets/styles/css/omni.css
+++ b/resources/public/assets/styles/css/omni.css
@@ -1,0 +1,92 @@
+/* Global box sizing */
+html {
+  box-sizing: border-box; }
+
+*, *:before, *:after {
+  box-sizing: inherit; }
+
+/* Clear floats */
+.hidden {
+  display: none; }
+
+/* all elements added to the page _must_ be under the omnibar's namespace */
+#doctopus-omnibar {
+  background: #333032;
+  color: #666165;
+  font: 100%/1.5 "proxima-nova-soft", Helvetica, Arial, sans-serif;
+  position: fixed;
+  top: 0;
+  left: 0;
+  -webkit-font-smoothing: antialiased; }
+  #doctopus-omnibar a {
+    text-decoration: none;
+    color: #17d4e5; }
+  #doctopus-omnibar #brand {
+    background: url(/assets/images/doctopus-favicon.png) #333032;
+    background-size: 32px 32px;
+    height: 32px;
+    width: 32px;
+    text-indent: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    margin: 0;
+    position: absolute;
+    top: 16px;
+    left: 16px; }
+    #doctopus-omnibar #brand a {
+      position: absolute;
+      display: block;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%; }
+  #doctopus-omnibar #sidebar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 20%;
+    min-width: 300px;
+    min-height: 75px;
+    background: #333032;
+    padding-top: 16px; }
+    #doctopus-omnibar #sidebar .logo {
+      background: url(/assets/images/doctopus-logo.png);
+      background-size: 125px 25px;
+      height: 25px;
+      width: 125px;
+      text-indent: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      margin: 0;
+      position: relative; }
+      #doctopus-omnibar #sidebar .logo a {
+        position: absolute;
+        display: block;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%; }
+    #doctopus-omnibar #sidebar .close {
+      position: absolute;
+      display: block;
+      top: 8px;
+      right: 8px;
+      overflow: hidden;
+      white-space: nowrap;
+      margin: 0; }
+      #doctopus-omnibar #sidebar .close a {
+        text-indent: 100%;
+        color: #fbfbfb; }
+        #doctopus-omnibar #sidebar .close a:before {
+          font-size: 1.2em;
+          margin-right: 0.2em;
+          content: "\00d7";
+          font-weight: bold; }
+    #doctopus-omnibar #sidebar .state {
+      margin: 1em 0.2em 0.2em 0.2em; }
+      #doctopus-omnibar #sidebar .state h1 {
+        color: #fbfbfb; }
+        #doctopus-omnibar #sidebar .state h1 a {
+          color: #fbfbfb; }
+        #doctopus-omnibar #sidebar .state h1 small {
+          font-weight: normal; }

--- a/resources/public/assets/styles/sass/_settings.scss
+++ b/resources/public/assets/styles/sass/_settings.scss
@@ -10,6 +10,7 @@ html {
 $base-color: #fbfbfb;
 $type-color: #666165;
 $link-color: #17d4e5;
+$dark-background: #333032;
 
 // Button colors
 $primary-color: #e517b2;

--- a/resources/public/assets/styles/sass/omni.scss
+++ b/resources/public/assets/styles/sass/omni.scss
@@ -5,8 +5,8 @@
     background: $dark-background;
     color: $type-color;
     font: 100%/1.5 "proxima-nova-soft", Helvetica, Arial, sans-serif;
-    height: 100%;
-    min-width: 1024px;
+    position: fixed;
+    top: 0; left: 0;
     -webkit-font-smoothing: antialiased;
 
     #brand {
@@ -27,6 +27,58 @@
             top: 0; left: 0;
             width: 100%;
             height: 100%;
+        }
+    }
+
+    #sidebar {
+        position: absolute;
+        top: 0; left: 0;
+        width: 20%;
+        min-width: 300px;
+        min-height: 75px;
+        background: $dark-background;
+        padding-top: 16px;
+
+        .logo {
+            background: url(/assets/images/doctopus-logo.png);
+            background-size: 125px 25px;
+            height: 25px;
+            width: 125px;
+            text-indent: 100%;
+            overflow: hidden;
+            white-space: nowrap;
+            margin: 0;
+            position: relative;
+
+            a {
+                position: absolute;
+                display: block;
+                top: 0; left: 0;
+                width: 100%;
+                height: 100%;
+            }
+        }
+
+        .close {
+            position: absolute;
+            display: block;
+            top: 8px; right: 8px;
+            overflow: hidden;
+            white-space: nowrap;
+            margin: 0;
+
+            a {
+                text-indent: 100%;
+                color: $base-color;
+                text-decoration: none;
+
+                &:before {
+                    font-size: 1.2em;
+                    margin-right: 0.2em;
+                    content: "\00d7";
+                    font-weight: bold;
+                }
+            }
         }
     }
 }

--- a/resources/public/assets/styles/sass/omni.scss
+++ b/resources/public/assets/styles/sass/omni.scss
@@ -9,6 +9,11 @@
     top: 0; left: 0;
     -webkit-font-smoothing: antialiased;
 
+    a {
+        text-decoration: none;
+        color: $link-color;
+    }
+
     #brand {
         background: url(/assets/images/doctopus-favicon.png) $dark-background;
         background-size: 32px 32px;
@@ -70,13 +75,28 @@
             a {
                 text-indent: 100%;
                 color: $base-color;
-                text-decoration: none;
 
                 &:before {
                     font-size: 1.2em;
                     margin-right: 0.2em;
                     content: "\00d7";
                     font-weight: bold;
+                }
+            }
+        }
+
+        .state {
+            margin: 1em 0.2em 0.2em 0.2em;
+
+            h1 {
+                color: $base-color;
+
+                a {
+                    color: $base-color;
+                }
+
+                small {
+                    font-weight: normal;
                 }
             }
         }

--- a/resources/public/assets/styles/sass/omni.scss
+++ b/resources/public/assets/styles/sass/omni.scss
@@ -1,0 +1,32 @@
+@import 'settings';
+
+/* all elements added to the page _must_ be under the omnibar's namespace */
+#doctopus-omnibar {
+    background: $dark-background;
+    color: $type-color;
+    font: 100%/1.5 "proxima-nova-soft", Helvetica, Arial, sans-serif;
+    height: 100%;
+    min-width: 1024px;
+    -webkit-font-smoothing: antialiased;
+
+    #brand {
+        background: url(/assets/images/doctopus-favicon.png) $dark-background;
+        background-size: 32px 32px;
+        height: 32px;
+        width: 32px;
+        text-indent: 100%;
+        overflow: hidden;
+        white-space: nowrap;
+        margin: 0;
+        position: absolute;
+        top: 16px; left: 16px;
+
+        a {
+            position: absolute;
+            display: block;
+            top: 0; left: 0;
+            width: 100%;
+            height: 100%;
+        }
+    }
+}

--- a/resources/templates/frame.html
+++ b/resources/templates/frame.html
@@ -1,5 +1,0 @@
-<div id="doctopus-iframe">
-  <ul>
-    <li><a href="#" id="doctopus-index">To Doctopus Index</a></li>
-  </ul>
-</div>

--- a/src-cljs/main.cljs
+++ b/src-cljs/main.cljs
@@ -3,19 +3,13 @@
             [doctopus.views.head-form :refer [head-form]]
             [doctopus.views.tentacle-form :refer [tentacle-form]]
             [doctopus.views.index :refer [main]]
+            [doctopus.util :refer [get-app-state]]
             [reagent.core :as reagent]))
 
 (def pages {:add-head head-form
             :add-tentacle tentacle-form
             :edit-tentacle tentacle-form
             :index main})
-
-(defn- get-app-state
-  []
-  (-> (dom/getElement "app-state")
-      (.-textContent)
-      (js/JSON.parse)
-      (js->clj :keywordize-keys true)))
 
 (defn- get-page-component
   [app-state]

--- a/src-cljs/omni.cljs
+++ b/src-cljs/omni.cljs
@@ -1,6 +1,7 @@
 (ns doctopus.omni
   (:require [goog.dom :as dom]
-            [reagent.core :as r]))
+            [reagent.core :as r]
+            [doctopus.util :refer [get-app-state]]))
 
 (enable-console-print!)
 
@@ -10,8 +11,7 @@
   [event]
   (.stopPropagation event)
   (.preventDefault event)
-  (swap! state assoc :open (not (:open @state)))
-  (println @state))
+  (swap! state assoc :open (not (:open @state))))
 
 (defn- brand-component
   []
@@ -29,22 +29,32 @@
   []
   [:div.logo [:a {:href "/"} "doctopus"]])
 
+(defn- state-component
+  [app-state]
+  (let [{:keys [tentacle-name]} app-state]
+    [:div.state
+     [:h1
+      [:small "currently viewing "]
+      [:a {:href (str "/docs/" tentacle-name)} tentacle-name]]]))
+
 (defn- sidebar-component
-  []
+  [full-state]
   [:div#sidebar
    [logo-component]
-   [close-component]])
+   [close-component]
+   [state-component (:context full-state)]])
 
 
 (defn omnibar
-  []
+  [context]
+  (swap! state assoc :context context)
   (let [{:keys [open]} @state]
     (if open
-      [sidebar-component]
+      [sidebar-component @state]
       [brand-component])))
 
 (defn init
   [component]
   (r/render-component component (dom/getElement "doctopus-omnibar")))
 
-(init [omnibar])
+(init [omnibar (get-app-state)])

--- a/src-cljs/omni.cljs
+++ b/src-cljs/omni.cljs
@@ -1,0 +1,15 @@
+(ns doctopus.omni
+  (:require [goog.dom :as dom]
+            [reagent.core :as reagent]))
+
+(defn omnibar
+  []
+  (fn []
+    [:div#brand
+     [:a {:href "/"} "doctopus"]]))
+
+(defn init
+  [component]
+  (reagent/render-component component (dom/getElement "doctopus-omnibar")))
+
+(init (omnibar))

--- a/src-cljs/omni.cljs
+++ b/src-cljs/omni.cljs
@@ -1,15 +1,50 @@
 (ns doctopus.omni
   (:require [goog.dom :as dom]
-            [reagent.core :as reagent]))
+            [reagent.core :as r]))
+
+(enable-console-print!)
+
+(defonce state (r/atom {:open false}))
+
+(defn- open-close-omnibar
+  [event]
+  (.stopPropagation event)
+  (.preventDefault event)
+  (swap! state assoc :open (not (:open @state)))
+  (println @state))
+
+(defn- brand-component
+  []
+  [:div#brand
+     [:a {:href "#"
+          :on-click open-close-omnibar} "doctopus"]])
+
+(defn- close-component
+  []
+  [:div.icon.close
+   [:a {:href "#"
+          :on-click open-close-omnibar} "close"]])
+
+(defn- logo-component
+  []
+  [:div.logo [:a {:href "/"} "doctopus"]])
+
+(defn- sidebar-component
+  []
+  [:div#sidebar
+   [logo-component]
+   [close-component]])
+
 
 (defn omnibar
   []
-  (fn []
-    [:div#brand
-     [:a {:href "/"} "doctopus"]]))
+  (let [{:keys [open]} @state]
+    (if open
+      [sidebar-component]
+      [brand-component])))
 
 (defn init
   [component]
-  (reagent/render-component component (dom/getElement "doctopus-omnibar")))
+  (r/render-component component (dom/getElement "doctopus-omnibar")))
 
-(init (omnibar))
+(init [omnibar])

--- a/src-cljs/util.cljs
+++ b/src-cljs/util.cljs
@@ -1,4 +1,5 @@
-(ns doctopus.util)
+(ns doctopus.util
+  (:require [goog.dom :as dom]))
 
 (enable-console-print!)
 
@@ -22,3 +23,11 @@
   "If pred passes, return (conj coll x), else return coll"
   [pred coll x]
   (if pred (conj coll x) coll))
+
+(defn get-app-state
+  "retrieve application state from a known page element"
+  []
+  (-> (dom/getElement "app-state")
+      (.-textContent)
+      (js/JSON.parse)
+      (js->clj :keywordize-keys true)))

--- a/src/doctopus/template.clj
+++ b/src/doctopus/template.clj
@@ -53,7 +53,7 @@
 (defn- app-context
   [context]
   (enlive/html
-    [:script#app-state {:type "application/javascript"} (json/write-str context)]))
+    [:script#app-state {:type "application/json"} (json/write-str context)]))
 
 (defn add-omnibar
   "given a string of HTML, returns a string with a the Doctopus omnibar inserted
@@ -62,7 +62,7 @@
   (-> html-str
       (prepend-to-element :body (omnibar-html))
       (prepend-to-element :head (omnibar-css))
-      (append-to-element :body (app-context context))))
+      (append-to-element :head (app-context context))))
 
 (defn- tentacle-context
   [tentacle]

--- a/src/doctopus/template.clj
+++ b/src/doctopus/template.clj
@@ -13,10 +13,27 @@
   (enlive/html
    [:iframe {:src "/frame.html" :width "100%" :height "90" :frameBorder "0"}]))
 
-(defn- prepend-frame
-  "injects the Doctopus iframe into the first body element of the given HTML"
-  [main frame]
-  (enlive/sniptest main [[:body enlive/first-of-type]] (enlive/prepend frame)))
+(defn- omnibar-html
+  "constructions domnibar (the doctopus omnibar) html"
+  []
+  (enlive/html
+    [:link {:rel "stylesheet" :href "/assets/styles/css/omni.css"}]
+    [:div#doctopus-omnibar]
+    [:script {:src "/assets/scripts/omni.js" :type "application/javascript"}]))
+
+(defn- omnibar-css
+  "constructs a stylesheet reference for the domnibar"
+  []
+  (enlive/html
+    [:script {:src "//use.typekit.net/txl6yqy.js" :type "application/javascript"}]
+    [:script "try{Typekit.load();}catch(e){}"]
+    [:link {:rel "stylesheet" :href "/assets/styles/css/omni.css"}]))
+
+(defn- prepend-to-element
+  ([main to-prepend]
+   (prepend-to-element main :body to-prepend))
+  ([main element to-prepend]
+   (enlive/sniptest main [[element enlive/first-of-type]] (enlive/prepend to-prepend))))
 
 (deftemplate base-template "templates/base.html"
   [context]
@@ -40,6 +57,13 @@
    its body"
   [html-str]
   (apply str (prepend-frame html-str (iframe-html))))
+
+(defn add-omnibar
+  "given a string of HTML, returns a string with a the Doctopus omnibar inserted
+  at the end of its body"
+  [html-str]
+  (apply str (prepend-to-element (prepend-to-element html-str :head (omnibar-css))
+                                 :body (omnibar-html))))
 
 (defn- tentacle-context
   [tentacle]

--- a/src/doctopus/template.clj
+++ b/src/doctopus/template.clj
@@ -28,12 +28,16 @@
   (enlive/sniptest main [[element enlive/first-of-type]] (f snippet)))
 
 (defn- append-to-element
+  "Given an an html string and an enlive-compiled html to-append, insert at the
+  end of the given element; defaults to :body"
   ([main to-append]
    (append-to-element main :body to-append))
   ([main element to-append]
    (add-to-element-with-fn main element to-append enlive/append)))
 
 (defn- prepend-to-element
+  "Given an an html string and an enlive-compiled html to-prepend, insert at the
+  beginning of the given element; defaults to :body"
   ([main to-prepend]
    (prepend-to-element main :body to-prepend))
   ([main element to-prepend]
@@ -51,13 +55,15 @@
   (apply str (base-template context)))
 
 (defn- app-context
+  "generates an enlive-encoded html description map for app-state; a known
+  element used to communicate context to the frontend cljs app on page load"
   [context]
   (enlive/html
     [:script#app-state {:type "application/json"} (json/write-str context)]))
 
 (defn add-omnibar
-  "given a string of HTML, returns a string with a the Doctopus omnibar inserted
-  at the end of its body"
+  "given a string of HTML, returns a string with a the Doctopus omnibar and
+  associated assets inserted into the appropriate places."
   [html-str context]
   (-> html-str
       (prepend-to-element :body (omnibar-html))

--- a/src/doctopus/template.clj
+++ b/src/doctopus/template.clj
@@ -7,12 +7,6 @@
             [ring.util.anti-forgery :as csrf]
             [ring.middleware.anti-forgery :as csrf-token]))
 
-(defn- iframe-html
-  "constructs an iframe element with relevant src attribute"
-  []
-  (enlive/html
-   [:iframe {:src "/frame.html" :width "100%" :height "90" :frameBorder "0"}]))
-
 (defn- omnibar-html
   "constructions domnibar (the doctopus omnibar) html"
   []
@@ -45,18 +39,6 @@
   "wraps the given body in the base template"
   [context]
   (apply str (base-template context)))
-
-(defn project-frame
-  "returns a string of HTML suitable for serving an iframe with doctopus
-   navigation"
-  []
-  (base-template ""))
-
-(defn add-frame
-  "given a string of HTML, returns a string with a Doctopus iframe inserted into
-   its body"
-  [html-str]
-  (apply str (prepend-frame html-str (iframe-html))))
 
 (defn add-omnibar
   "given a string of HTML, returns a string with a the Doctopus omnibar inserted

--- a/src/doctopus/web.clj
+++ b/src/doctopus/web.clj
@@ -135,7 +135,7 @@
           file (:body response)
           tentacle-name (get-tentacle-from-uri (:uri request))]
       (if (and tentacle-name file (html? file))
-        (assoc response :body (templates/add-omnibar (slurp file)))
+        (assoc response :body (templates/add-omnibar (slurp file) {:tentacle-name tentacle-name}))
         response))))
 
 (defn create-application

--- a/src/doctopus/web.clj
+++ b/src/doctopus/web.clj
@@ -133,21 +133,21 @@
   [routes]
   (bidi/make-handler routes))
 
-(defn wrap-iframe-transform
+(defn wrap-omnibar-transform
   [handler]
   (fn [request]
     (let [response (handler request)
           file (:body response)
           tentacle-name (get-tentacle-from-uri (:uri request))]
       (if (and tentacle-name file (html? file))
-        (assoc response :body (templates/add-frame (slurp file)))
+        (assoc response :body (templates/add-omnibar (slurp file)))
         response))))
 
 (defn create-application
   [app-handlers]
   (-> (wrap-defaults app-handlers site-defaults)
       (wrap-json-body)
-      (wrap-iframe-transform)
+      (wrap-omnibar-transform)
       (wrap-route-not-found)
       (reload/wrap-reload)
       ((if (= (:env (server-config)) :production)

--- a/src/doctopus/web.clj
+++ b/src/doctopus/web.clj
@@ -73,10 +73,6 @@
   [_]
   (serve-html (templates/index doctopus)))
 
-(defn serve-iframe
-  [_]
-  (serve-html (templates/project-frame)))
-
 (defn serve-add-head-form
   [_]
   (serve-html (templates/add-head doctopus)))
@@ -116,7 +112,6 @@
   ["/" {""             {:get serve-index}
         "index.html"   {:get serve-index}
         "assets"       (->Resources {:prefix "public/assets"})
-        "frame.html"   {:get serve-iframe}
         "heads"        {"/"           {:get serve-all-heads}
                         ""            {:get serve-all-heads}
                         [:head-name]  {:get serve-head}}

--- a/test/doctopus/template_test.clj
+++ b/test/doctopus/template_test.clj
@@ -6,6 +6,24 @@
             [net.cgrand.enlive-html :as enlive]))
 
 (deftest template
-  (testing "add-frame injects an iframe in the body element"
-    (is (not (nil? (re-find #"\<body\>\<iframe.*?\>\</body\>"
-                            (add-frame "<body></body>")))))))
+  (testing "append inserts html at end of selection"
+    (is (= "<body><div>test</div><div>inserted</div></body>"
+           (#'doctopus.template/append-to-element
+             "<body><div>test</div></body>"
+             :body
+             (enlive/html [:div "inserted"])))))
+
+  (testing "prepend inserts html at beginning of selection"
+    (is (= "<body><div>inserted</div><div>test</div></body>"
+           (#'doctopus.template/prepend-to-element
+             "<body><div>test</div></body>"
+             :body
+             (enlive/html [:div "inserted"])))))
+
+  (testing "add-omnibar inserts omnibar and context into existing html"
+    (is (not (nil? (re-find #"omnibar"
+                            (add-omnibar "<head></head><body></body>" {})))))
+    (is (not (nil? (re-find #"muh-context"
+                            (add-omnibar "<head></head><body></body>"
+                                         {:muh-context true})))))))
+


### PR DESCRIPTION
the doctopus omnibar (domnibar) is a javascript-injected persistent navigation component; right now it doesn't do an awful lot besides give a way back to the documentation's index as well as the homepage, but this will give us a nice place to put any other features we decide to add (first will be a persistent search)

![2015-12-09-165416_1276x688_scrot](https://cloud.githubusercontent.com/assets/2207657/11703613/8dd5d146-9e95-11e5-810f-3109379e58af.png)
![2015-12-09-165426_1276x688_scrot](https://cloud.githubusercontent.com/assets/2207657/11703614/8dd68546-9e95-11e5-904f-2aa93b60c469.png)
