### PR TITLE
fixes cljsbuilds, makes non-figwheel the default; updates README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ pom.xml.asc
 *.swo
 /docs-tmp/
 /resources/configuration-local.edn
+/resources/public/assets/scripts
 /figwheel_server.log

--- a/README.md
+++ b/README.md
@@ -45,12 +45,50 @@ in there and you'll be good to go to get the whole thing spun up:
 
 (You can, of course, set `NOMAD_ENV` in the `rc` file of your choice.)
 
+### ClojureScript
+
+ClojureScript is build with [cljsbuild][], which has a few different profiles
+that you can use to build. If you're only interested in trying things out, the
+simplest is to build with the default profile:
+
+```bash
+lein cljsbuild once
+```
+
+This will get you set up to run the local server.
+
+For development, [figwheel][] is included. Do the following to get the figwheel
+server running and autobuilding:
+
+```bash
+lein with-profile figwheel figwheel dev dev-omni # yes, figwheel twice!
+```
+
+### SASS
+
+The stylesheets are currently checked into the repository as compiled CSS and as
+the source SASS, since they cannot be compiled without the help of an external
+tool. If you're not working on styles, you can just use what's included, but if
+you'd like to make style changes, you'll need either `node-sass` or the `sass`
+Ruby Gem.
+
+To compile with `node-sass`:
+
+```bash
+npm install -g node-sass
+cd resources/public/assets/styles
+node-sass --include-path ./sass --watch ./sass --output ./css ./sass
+```
+
+This will set up an auto-watching build server for CSS.
+
 ## Usage
 
 Right now: you don't.
 
 ### Free-range TODO List and Known Improvements
 
+See the [issues][].
 
 ## License
 
@@ -58,3 +96,7 @@ Copyright © 2015 Ross Donaldson
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.
+
+[cljsbuild]: https://github.com/emezeske/lein-cljsbuild
+[figwheel]: https://github.com/bhauman/lein-figwheel
+[issues]: https://github.com/Gastove/doctopus/issues

--- a/project.clj
+++ b/project.clj
@@ -68,7 +68,7 @@
                                              :compiler {:main doctopus.main
                                                         :source-map "resources/public/assets/scripts/main.js.map"
                                                         :output-to "resources/public/assets/scripts/main.js"
-                                                        :asset-path "/assets/scripts"
+                                                        :asset-path "/assets/scripts/main"
                                                         :optimizations :advanced
                                                         :pretty-print false}}
                                             {:id "prod-omni"
@@ -77,7 +77,7 @@
                                              :compiler {:main doctopus.omni
                                                         :source-map "resources/public/assets/scripts/omni.js.map"
                                                         :output-to "resources/public/assets/scripts/omni.js"
-                                                        :asset-path "/assets/scripts"
+                                                        :asset-path "/assets/scripts/omni"
                                                         :optimizations :advanced
                                                         :pretty-print false}}]}}
              :figwheel {:cljsbuild {:builds [{:id "dev"

--- a/project.clj
+++ b/project.clj
@@ -39,24 +39,24 @@
   :target-path "target/%s"
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src-cljs"]
-                        :figwheel true
+                        :figwheel false
                         :incremental false
                         :compiler {:main doctopus.main
                                    :source-map "resources/public/assets/scripts/main.js.map"
                                    :output-to "resources/public/assets/scripts/main.js"
-                                   :output-dir "resources/public/assets/scripts"
-                                   :asset-path "/assets/scripts"
+                                   :output-dir "resources/public/assets/scripts/main"
+                                   :asset-path "/assets/scripts/main"
                                    :optimizations :none
                                    :pretty-print true}}
                        {:id "dev-omni"
                         :source-paths ["src-cljs"]
-                        :figwheel true
+                        :figwheel false
                         :incremental false
                         :compiler {:main doctopus.omni
                                    :source-map "resources/public/assets/scripts/omni.js.map"
                                    :output-to "resources/public/assets/scripts/omni.js"
-                                   :output-dir "resources/public/assets/scripts"
-                                   :asset-path "/assets/scripts"
+                                   :output-dir "resources/public/assets/scripts/omni"
+                                   :asset-path "/assets/scripts/omni"
                                    :optimizations :none
                                    :pretty-print true}}]}
   :profiles {:uberjar {:aot :all
@@ -79,4 +79,26 @@
                                                         :output-to "resources/public/assets/scripts/omni.js"
                                                         :asset-path "/assets/scripts"
                                                         :optimizations :advanced
-                                                        :pretty-print false}}]}}})
+                                                        :pretty-print false}}]}}
+             :figwheel {:cljsbuild {:builds [{:id "dev"
+                                              :source-paths ["src-cljs"]
+                                              :figwheel true
+                                              :incremental false
+                                              :compiler {:main doctopus.main
+                                                         :source-map "resources/public/assets/scripts/main.js.map"
+                                                         :output-to "resources/public/assets/scripts/main.js"
+                                                         :output-dir "resources/public/assets/scripts/main"
+                                                         :asset-path "/assets/scripts/main"
+                                                         :optimizations :none
+                                                         :pretty-print true}}
+                                             {:id "dev-omni"
+                                              :source-paths ["src-cljs"]
+                                              :figwheel true
+                                              :incremental false
+                                              :compiler {:main doctopus.omni
+                                                         :source-map "resources/public/assets/scripts/omni.js.map"
+                                                         :output-to "resources/public/assets/scripts/omni.js"
+                                                         :output-dir "resources/public/assets/scripts/omni"
+                                                         :asset-path "/assets/scripts/omni"
+                                                         :optimizations :none
+                                                         :pretty-print true}}]}}})


### PR DESCRIPTION
the figwheel cljsbuild isn't a sensible default for most; fixes the default cljsbuild to something that'll work out of the box, and adds a profile for using figwheel if you want it.

updates the README with instructions on both (and on building SASS for good measure)
