### PR TITLE
Monolithic clojurescript build

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ For development, [figwheel][] is included. Do the following to get the figwheel
 server running and autobuilding:
 
 ```bash
-lein with-profile figwheel figwheel dev dev-omni # yes, figwheel twice!
+lein figwheel
 ```
+
+**Note:** ClojureScript building for the local dev environment assumes your lein
+environment is `:dev`; which is the case by default.
 
 ### SASS
 

--- a/env/dev/src-cljs/doctopus/main.cljs
+++ b/env/dev/src-cljs/doctopus/main.cljs
@@ -1,0 +1,9 @@
+(ns doctopus.dev.main
+  (:require [doctopus.main :as main]
+            [doctopus.omni :as omni]
+            [doctopus.util :refer [get-app-state]]))
+
+(def app-state (get-app-state))
+
+(main/init! app-state)
+(omni/init! [omni/omnibar app-state])

--- a/env/prod/src-cljs/doctopus/main.cljs
+++ b/env/prod/src-cljs/doctopus/main.cljs
@@ -1,0 +1,9 @@
+(ns doctopus.prod.main
+  (:require [doctopus.main :as main]
+            [doctopus.omni :as omni]
+            [doctopus.util :refer [get-app-state]]))
+
+(def app-state (get-app-state))
+
+(main/init! app-state)
+(omni/init! [omni/omnibar app-state])

--- a/project.clj
+++ b/project.clj
@@ -37,68 +37,32 @@
             [lein-cljsbuild "1.1.1" :exclusions [org.clojure/clojurescript]]]
   :main ^:skip-aot doctopus.web
   :target-path "target/%s"
-  :cljsbuild {:builds [{:id "dev"
-                        :source-paths ["src-cljs"]
+  :cljsbuild {:builds [{:source-paths ["env/dev/src-cljs" "src-cljs"]
                         :figwheel false
                         :incremental false
-                        :compiler {:main doctopus.main
+                        :compiler {:main doctopus.dev.main
                                    :source-map "resources/public/assets/scripts/main.js.map"
                                    :output-to "resources/public/assets/scripts/main.js"
                                    :output-dir "resources/public/assets/scripts/main"
                                    :asset-path "/assets/scripts/main"
                                    :optimizations :none
-                                   :pretty-print true}}
-                       {:id "dev-omni"
-                        :source-paths ["src-cljs"]
-                        :figwheel false
-                        :incremental false
-                        :compiler {:main doctopus.omni
-                                   :source-map "resources/public/assets/scripts/omni.js.map"
-                                   :output-to "resources/public/assets/scripts/omni.js"
-                                   :output-dir "resources/public/assets/scripts/omni"
-                                   :asset-path "/assets/scripts/omni"
-                                   :optimizations :none
                                    :pretty-print true}}]}
   :profiles {:uberjar {:aot :all
-                       :prep-tasks ["compile" ["cljsbuild" "once" "prod" "prod-omni"]]
+                       :prep-tasks ["compile" ["cljsbuild" "once"]]
                        :cljsbuild {:jar true
-                                   :builds [{:id "prod"
-                                             :source-paths ["src-cljs"]
+                                   :builds [{:source-paths ["env/prod/src-cljs" "src-cljs"]
                                              :figwheel false
-                                             :compiler {:main doctopus.main
-                                                        :source-map "resources/public/assets/scripts/main.js.map"
-                                                        :output-to "resources/public/assets/scripts/main.js"
-                                                        :asset-path "/assets/scripts/main"
-                                                        :optimizations :advanced
-                                                        :pretty-print false}}
-                                            {:id "prod-omni"
-                                             :source-paths ["src-cljs"]
-                                             :figwheel false
-                                             :compiler {:main doctopus.omni
-                                                        :source-map "resources/public/assets/scripts/omni.js.map"
-                                                        :output-to "resources/public/assets/scripts/omni.js"
-                                                        :asset-path "/assets/scripts/omni"
+                                             :compiler {:output-to "resources/public/assets/scripts/main.js"
                                                         :optimizations :advanced
                                                         :pretty-print false}}]}}
              :figwheel {:cljsbuild {:builds [{:id "dev"
-                                              :source-paths ["src-cljs"]
+                                              :source-paths ["env/dev/src-cljs" "src-cljs"]
                                               :figwheel true
                                               :incremental false
-                                              :compiler {:main doctopus.main
+                                              :compiler {:main doctopus.dev.main
                                                          :source-map "resources/public/assets/scripts/main.js.map"
                                                          :output-to "resources/public/assets/scripts/main.js"
                                                          :output-dir "resources/public/assets/scripts/main"
                                                          :asset-path "/assets/scripts/main"
-                                                         :optimizations :none
-                                                         :pretty-print true}}
-                                             {:id "dev-omni"
-                                              :source-paths ["src-cljs"]
-                                              :figwheel true
-                                              :incremental false
-                                              :compiler {:main doctopus.omni
-                                                         :source-map "resources/public/assets/scripts/omni.js.map"
-                                                         :output-to "resources/public/assets/scripts/omni.js"
-                                                         :output-dir "resources/public/assets/scripts/omni"
-                                                         :asset-path "/assets/scripts/omni"
                                                          :optimizations :none
                                                          :pretty-print true}}]}}})

--- a/project.clj
+++ b/project.clj
@@ -32,37 +32,35 @@
                                               javax.jms/jms
                                               com.sun.jdmk/jmxtools
                                               com.sun.jmx/jmxri]]]
-  :plugins [[michaelblume/lein-marginalia "0.9.0" :exclusions [org.clojure/clojurescript]]
-            [lein-figwheel "0.5.0-2" :exclusions [joda-time]]
-            [lein-cljsbuild "1.1.1" :exclusions [org.clojure/clojurescript]]]
+  :plugins [[michaelblume/lein-marginalia "0.9.0" :exclusions [org.clojure/clojurescript]]]
   :main ^:skip-aot doctopus.web
   :target-path "target/%s"
-  :cljsbuild {:builds [{:source-paths ["env/dev/src-cljs" "src-cljs"]
-                        :figwheel false
-                        :incremental false
-                        :compiler {:main doctopus.dev.main
-                                   :source-map "resources/public/assets/scripts/main.js.map"
-                                   :output-to "resources/public/assets/scripts/main.js"
-                                   :output-dir "resources/public/assets/scripts/main"
-                                   :asset-path "/assets/scripts/main"
-                                   :optimizations :none
-                                   :pretty-print true}}]}
-  :profiles {:uberjar {:aot :all
-                       :prep-tasks ["compile" ["cljsbuild" "once"]]
-                       :cljsbuild {:jar true
-                                   :builds [{:source-paths ["env/prod/src-cljs" "src-cljs"]
-                                             :figwheel false
-                                             :compiler {:output-to "resources/public/assets/scripts/main.js"
-                                                        :optimizations :advanced
-                                                        :pretty-print false}}]}}
-             :figwheel {:cljsbuild {:builds [{:id "dev"
-                                              :source-paths ["env/dev/src-cljs" "src-cljs"]
-                                              :figwheel true
-                                              :incremental false
-                                              :compiler {:main doctopus.dev.main
-                                                         :source-map "resources/public/assets/scripts/main.js.map"
-                                                         :output-to "resources/public/assets/scripts/main.js"
-                                                         :output-dir "resources/public/assets/scripts/main"
-                                                         :asset-path "/assets/scripts/main"
-                                                         :optimizations :none
-                                                         :pretty-print true}}]}}})
+  :clean-targets ^{:protect false} [:target-path
+                                    [:cljsbuild :builds :app :compiler :output-dir]
+                                    [:cljsbuild :builds :app :compiler :output-to]]
+  :cljsbuild {:builds {:app {:source-paths ["src-cljs"]
+                             :compiler     {:output-to     "resources/public/assets/scripts/main.js"
+                                            :output-dir    "resources/public/assets/scripts/out"
+                                            :asset-path    "/assets/scripts/out"
+                                            :optimizations :none
+                                            :pretty-print  true}}}}
+  :profiles {:dev      {:repl-options {:init-ns doctopus.web}
+                        :dependencies [[lein-figwheel "0.4.1"]
+                                       [org.clojure/tools.nrepl "0.2.11"]]
+                        :plugins      [[lein-figwheel "0.5.0-2" :exclusions [joda-time]]
+                                       [lein-cljsbuild "1.1.1" :exclusions [org.clojure/clojurescript]]]
+                        :env          {:dev true}
+                        :cljsbuild    {:builds {:app {:source-paths ["env/dev/src-cljs"]
+                                                      :figwheel     true
+                                                      :compiler     {:main       "doctopus.dev.main"
+                                                                     :source-map true}}}}}
+             :uberjar  {:hooks       [leiningen.cljsbuild]
+                        :env         {:production true}
+                        :aot         :all
+                        :omit-source true
+                        :cljsbuild   {:jar    true
+                                      :builds {:app
+                                               {:source-paths ["env/prod/src-cljs"]
+                                                :compiler
+                                                              {:optimizations :advanced
+                                                               :pretty-print  false}}}}}})

--- a/src-cljs/main.cljs
+++ b/src-cljs/main.cljs
@@ -16,10 +16,8 @@
   (if-let [page (:page app-state)]
     [((keyword page) pages) app-state]))
 
-(defn init
+(defn init!
   [app-state]
   (if-let [page-component (get-page-component app-state)]
     (reagent/render-component page-component (dom/getElement "app-content"))
     (js/console.debug "Abandoning init: no component is defined for this page")))
-
-(init (get-app-state))

--- a/src-cljs/omni.cljs
+++ b/src-cljs/omni.cljs
@@ -53,8 +53,8 @@
       [sidebar-component @state]
       [brand-component])))
 
-(defn init
+(defn init!
   [component]
-  (r/render-component component (dom/getElement "doctopus-omnibar")))
-
-(init [omnibar (get-app-state)])
+  (if-let [el (dom/getElement "doctopus-omnibar")]
+    (r/render-component component el)
+    (js/console.debug "omnibar: element not present, not loading")))

--- a/src/doctopus/template.clj
+++ b/src/doctopus/template.clj
@@ -13,7 +13,7 @@
   (enlive/html
     [:link {:rel "stylesheet" :href "/assets/styles/css/omni.css"}]
     [:div#doctopus-omnibar]
-    [:script {:src "/assets/scripts/omni.js" :type "application/javascript"}]))
+    [:script {:src "/assets/scripts/main.js" :type "application/javascript"}]))
 
 (defn- omnibar-css
   "constructs a stylesheet reference for the domnibar"


### PR DESCRIPTION
So it turns out many of the reasons I was fighting cljsbuild were because it expects only a single file to be output ideally; this PR aligns us with that. It's based off the reagent leiningen template (what you'd get with a `lein new reagent` that I used for [mkwords](https://mkwords.fardog.io).

This changes how the cljs app's entry points work; there's now a separate entry point for dev and prod profiles, which perform the init of the main and omnibar components; if the known elements that each of these expect don't exist, they won't load.

This also really simplifies the process of getting the dev environment working, and should also make builds cleaner (since the plugins aren't required for building a prod env) if we ever decide to build from CI.

Also now correctly cleans the cljs project when a `lein clean` is run.
